### PR TITLE
git-annex: update to 10.20230321

### DIFF
--- a/devel/git-annex/Portfile
+++ b/devel/git-annex/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           haskell_stack 1.0
 
 name                git-annex
-version             7.20190819
-checksums           rmd160  596f70e63d93b37f449869a84ff6677e9a4e8af4 \
-                    sha256  9e794baf81f3fcc0359ec9c0f22f5d5cad1ea9446958e53acafe747c48ef7ebb \
-                    size    1253032
+version             10.20230321
+checksums           rmd160  d6ddd3c9ccce684f0d788c1308b6f451aa1a28c7 \
+                    sha256  7f4580835bdaeef8ae8c1c8f61abb43aafc39b986446d13093769aecbe047bd1 \
+                    size    1454067
 
 description         git-annex allows managing files with git, without checking the file contents into git
 long_description    \


### PR DESCRIPTION
#### Description

Update git-annex to 10.20230321.

This still only installs the `git-annex` binary without `git-annex-shell` (see https://git-annex.branchable.com/install/fromsource/). 
All tests in `git annex test` pass, except where `git-annex-shell` is involved (ssh remote tests).

Maybe closes: https://trac.macports.org/ticket/64477

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
